### PR TITLE
don't delete the assets symlink if it's already set correctly

### DIFF
--- a/lib/sets/Instance.js
+++ b/lib/sets/Instance.js
@@ -89,16 +89,22 @@ Instance.prototype.update = function () {
 
 Instance.prototype.updateFlow = function () {
   let self = this;
+  let index = JSON.parse(fs.readFileSync(self.indexPath));
+  let targetPath = path.resolve(path.dirname(self.indexPath), index.cwd || "./");
   return Q
-      .nfcall(fsCommons.access, self.assetsPath, fs.W_OK)
-      .then(function () { return Q.nfcall(fs.unlink, self.assetsPath); },
-          function () { wrench.mkdirSyncRecursive(path.dirname(self.assetsPath)); })
-      .then(function () {
-        let index = JSON.parse(fs.readFileSync(self.indexPath));
-        return Q
-            .nfcall(fs.symlink, path.resolve(path.dirname(self.indexPath), index.cwd || "./"), self.assetsPath, "dir")
-            .then(_.constant(index));
-      });
+      .nfcall(fs.realpath, self.assetsPath)
+      .then(function (resolved) {
+            if (resolved === targetPath) return true;
+	    else return Q
+                .nfcall(fs.unlink, self.assetsPath)
+                .then(_.constant(false));
+          },
+          function () { wrench.mkdirSyncRecursive(path.dirname(self.assetsPath)); return false; })
+      .then(function (ok) {
+            if (ok) return;
+            return Q.nfcall(fs.symlink, targetPath, self.assetsPath, "dir");
+          })
+      .then(function () { return _.constant(index); });
 };
 
 Instance.prototype.widthAttribute = function (ignored, name) { return this.dataById[name].width; };


### PR DESCRIPTION
I'm not sure what the formatting conventions are, but I tried to emulate them as closely as I could.

This is causing my clustered install of NodeBB to not have emoji on some instances at random.
